### PR TITLE
Add per-domain tab limits feature

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,29 +1,75 @@
-let maxTabs = 10; // Default maximum number of tabs
+let maxTabs = 40; // Default maximum number of tabs
 let tabTimestamps = {};
 let excludedUrls = []; // List of excluded domains or URLs
+let domainLimits = {}; // Per-domain tab limits (e.g., { "x.com": 3, "twitter.com": 3 })
+let initialized = false;
 
-// Load settings from storage
-chrome.storage.local.get(['maxTabs', 'excludedUrls'], function (result) {
-    if (result.maxTabs) {
-        maxTabs = result.maxTabs;
-    }
-    if (result.excludedUrls) {
-        excludedUrls = result.excludedUrls;
-    }
-});
+// Initialize extension - load settings and tab timestamps from storage
+async function initialize() {
+    if (initialized) return;
 
-// Initialize tabTimestamps for existing tabs
-chrome.tabs.query({}).then((tabs) => {
-    let timestamp = Date.now();
-    tabs.sort((a, b) => a.index - b.index);
-    tabs.forEach((tab, idx) => {
-        if (!tabTimestamps[tab.id]) {
-            // Assign older timestamps to older tabs
-            tabTimestamps[tab.id] = timestamp - (tabs.length - idx);
+    try {
+        // Load all settings from storage first
+        const result = await chrome.storage.local.get(['maxTabs', 'excludedUrls', 'tabTimestamps', 'domainLimits']);
+
+        if (result.maxTabs) {
+            maxTabs = result.maxTabs;
         }
-    });
-    updateBadgeText(tabs.length);
-});
+        if (result.excludedUrls) {
+            excludedUrls = result.excludedUrls;
+        }
+        if (result.tabTimestamps) {
+            tabTimestamps = result.tabTimestamps;
+        }
+        if (result.domainLimits) {
+            domainLimits = result.domainLimits;
+        }
+
+        // Initialize tabTimestamps for existing tabs that don't have timestamps
+        const tabs = await chrome.tabs.query({});
+        let timestamp = Date.now();
+        tabs.sort((a, b) => a.index - b.index);
+
+        let needsUpdate = false;
+        tabs.forEach((tab, idx) => {
+            if (!tabTimestamps[tab.id]) {
+                // Assign older timestamps to older tabs
+                tabTimestamps[tab.id] = timestamp - (tabs.length - idx);
+                needsUpdate = true;
+            }
+        });
+
+        // Clean up timestamps for tabs that no longer exist
+        const existingTabIds = new Set(tabs.map(tab => tab.id));
+        for (const tabId of Object.keys(tabTimestamps)) {
+            if (!existingTabIds.has(parseInt(tabId))) {
+                delete tabTimestamps[tabId];
+                needsUpdate = true;
+            }
+        }
+
+        if (needsUpdate) {
+            await saveTabTimestamps();
+        }
+
+        updateBadgeText(tabs.length);
+        initialized = true;
+    } catch (error) {
+        console.error('Error initializing extension:', error);
+    }
+}
+
+// Save tabTimestamps to storage (persists across service worker restarts)
+async function saveTabTimestamps() {
+    try {
+        await chrome.storage.local.set({ tabTimestamps });
+    } catch (error) {
+        console.error('Error saving tabTimestamps:', error);
+    }
+}
+
+// Run initialization
+initialize();
 
 // Listen for changes in storage to update settings
 chrome.storage.onChanged.addListener(function (changes, areaName) {
@@ -36,66 +82,135 @@ chrome.storage.onChanged.addListener(function (changes, areaName) {
             excludedUrls = changes.excludedUrls.newValue;
             checkTabCount();
         }
+        if (changes.domainLimits) {
+            domainLimits = changes.domainLimits.newValue || {};
+            checkTabCount();
+        }
+        // Update local tabTimestamps if changed externally (shouldn't happen normally)
+        if (changes.tabTimestamps && changes.tabTimestamps.newValue) {
+            tabTimestamps = changes.tabTimestamps.newValue;
+        }
     }
 });
 
 // Update timestamp when a tab is created
-chrome.tabs.onCreated.addListener(function (tab) {
+chrome.tabs.onCreated.addListener(async function (tab) {
+    await initialize(); // Ensure initialized before handling events
     let timestamp = Date.now();
     tabTimestamps[tab.id] = timestamp;
+    await saveTabTimestamps();
     updateBadgeText();
     checkTabCount();
 });
 
 // Update timestamp when a tab is updated
-chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+chrome.tabs.onUpdated.addListener(async function (tabId, changeInfo, tab) {
     if (changeInfo.status === 'complete') {
+        await initialize(); // Ensure initialized before handling events
         let timestamp = Date.now();
         tabTimestamps[tabId] = timestamp;
+        await saveTabTimestamps();
         updateBadgeText();
         checkTabCount();
     }
 });
 
 // Update timestamp when a tab is activated
-chrome.tabs.onActivated.addListener(function (activeInfo) {
+chrome.tabs.onActivated.addListener(async function (activeInfo) {
+    await initialize(); // Ensure initialized before handling events
     let timestamp = Date.now();
     tabTimestamps[activeInfo.tabId] = timestamp;
+    await saveTabTimestamps();
     updateBadgeText();
     checkTabCount();
 });
 
 // Remove tab from tabTimestamps when closed
-chrome.tabs.onRemoved.addListener(function (tabId, removeInfo) {
+chrome.tabs.onRemoved.addListener(async function (tabId, removeInfo) {
+    await initialize(); // Ensure initialized before handling events
     delete tabTimestamps[tabId];
+    await saveTabTimestamps();
     updateBadgeText();
-    // Removed checkTabCount() call to prevent recursive behavior
 });
 
 // Listen for messages from options page or popup
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     if (request.action === 'checkTabCount') {
-        checkTabCount();
+        initialize().then(() => checkTabCount());
+        sendResponse({ success: true });
     } else if (request.action === 'getTabStats') {
         chrome.tabs.query({}).then((tabs) => {
             sendResponse({ tabCount: tabs.length });
+        }).catch((error) => {
+            console.error('Error getting tab stats:', error);
+            sendResponse({ error: error.message });
         });
         return true; // Indicates async response
     }
+    return false;
 });
 
 // Function to enforce the tab limit
 async function checkTabCount() {
     try {
+        await initialize(); // Ensure initialized before checking
+
         let tabs = await chrome.tabs.query({});
-        let totalTabs = tabs.length;
-        let pinnedTabs = tabs.filter(tab => tab.pinned).length;
         let nonPinnedTabs = tabs.filter(tab => !tab.pinned);
-        let nonPinnedTabCount = nonPinnedTabs.length;
 
         // Filter out tabs in the excluded URLs
         let tabsToConsider = nonPinnedTabs.filter(tab => !isExcluded(tab.url));
 
+        let allTabsClosed = [];
+
+        // First, enforce per-domain limits
+        if (Object.keys(domainLimits).length > 0) {
+            // Group tabs by domain
+            const tabsByDomain = {};
+            for (const tab of tabsToConsider) {
+                const domain = getDomain(tab.url);
+                if (domain) {
+                    if (!tabsByDomain[domain]) {
+                        tabsByDomain[domain] = [];
+                    }
+                    tabsByDomain[domain].push(tab);
+                }
+            }
+
+            // Check each domain with a limit
+            for (const [domain, limit] of Object.entries(domainLimits)) {
+                const domainTabs = tabsByDomain[domain] || [];
+
+                if (domainTabs.length > limit) {
+                    // Sort by last accessed time (oldest first)
+                    const tabTimes = domainTabs.map(tab => ({
+                        id: tab.id,
+                        time: tabTimestamps[tab.id] || 0
+                    }));
+                    tabTimes.sort((a, b) => a.time - b.time);
+
+                    // Close oldest tabs to bring count down to limit
+                    const tabsToCloseCount = domainTabs.length - limit;
+                    for (let i = 0; i < tabsToCloseCount; i++) {
+                        const tabId = tabTimes[i].id;
+                        try {
+                            await chrome.tabs.remove(tabId);
+                            delete tabTimestamps[tabId];
+                            allTabsClosed.push({ id: tabId, domain });
+                        } catch (error) {
+                            console.error(`Error removing tab ${tabId}:`, error);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Re-query tabs after domain limit enforcement
+        tabs = await chrome.tabs.query({});
+        nonPinnedTabs = tabs.filter(tab => !tab.pinned);
+        tabsToConsider = nonPinnedTabs.filter(tab => !isExcluded(tab.url));
+
+        // Then, enforce global limit
         if (tabsToConsider.length > maxTabs) {
             // Get tabs sorted by last accessed time
             let tabTimes = tabsToConsider.map(tab => ({ id: tab.id, time: tabTimestamps[tab.id] || 0 }));
@@ -105,32 +220,67 @@ async function checkTabCount() {
             let tabsToCloseCount = tabsToConsider.length - maxTabs;
 
             // Close the oldest tabs
-            let tabsClosed = [];
             for (let i = 0; i < tabsToCloseCount; i++) {
                 let tabId = tabTimes[i].id;
                 try {
                     await chrome.tabs.remove(tabId);
                     delete tabTimestamps[tabId];
-                    tabsClosed.push(tabId);
+                    allTabsClosed.push({ id: tabId, domain: 'global' });
                 } catch (error) {
                     console.error(`Error removing tab ${tabId}:`, error);
                 }
             }
-
-            // Display notification
-            if (tabsClosed.length > 0) {
-                let message = `Closed ${tabsClosed.length} tab(s) to maintain the limit of ${maxTabs}.`;
-                chrome.notifications.create({
-                    type: 'basic',
-                    iconUrl: 'icons/icon128.png',
-                    title: 'Tab Limiter',
-                    message: message
-                });
-            }
         }
-        updateBadgeText(totalTabs);
+
+        // Save updated tabTimestamps and show notification
+        if (allTabsClosed.length > 0) {
+            await saveTabTimestamps();
+
+            // Create notification message
+            const domainCounts = {};
+            let globalCount = 0;
+            for (const { domain } of allTabsClosed) {
+                if (domain === 'global') {
+                    globalCount++;
+                } else {
+                    domainCounts[domain] = (domainCounts[domain] || 0) + 1;
+                }
+            }
+
+            let messageParts = [];
+            for (const [domain, count] of Object.entries(domainCounts)) {
+                messageParts.push(`${count} from ${domain}`);
+            }
+            if (globalCount > 0) {
+                messageParts.push(`${globalCount} for global limit`);
+            }
+
+            const message = `Closed ${allTabsClosed.length} tab(s): ${messageParts.join(', ')}.`;
+            chrome.notifications.create({
+                type: 'basic',
+                iconUrl: 'icons/icon128.png',
+                title: 'Tab Limiter',
+                message: message
+            });
+        }
+
+        // Update badge with current tab count
+        let currentTabs = await chrome.tabs.query({});
+        updateBadgeText(currentTabs.length);
     } catch (error) {
         console.error('Error in checkTabCount:', error);
+    }
+}
+
+// Function to extract domain from a URL
+function getDomain(url) {
+    if (!url) return null;
+    try {
+        const urlObj = new URL(url);
+        // Return hostname without 'www.' prefix for consistent matching
+        return urlObj.hostname.replace(/^www\./, '');
+    } catch (e) {
+        return null;
     }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Tab Limiter",
-    "version": "1.1",
+    "version": "1.2",
     "description": "Closes the oldest open tabs if the total number exceeds a user-specified limit.",
     "permissions": [
         "tabs",

--- a/options.html
+++ b/options.html
@@ -7,6 +7,7 @@
         body {
             font-family: Arial, sans-serif;
             margin: 20px;
+            max-width: 500px;
         }
 
         label,
@@ -30,20 +31,90 @@
         textarea {
             height: 100px;
         }
+
+        .section {
+            margin-bottom: 20px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid #ddd;
+        }
+
+        .domain-limit-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-top: 8px;
+        }
+
+        .domain-limit-row input[type="text"] {
+            flex: 2;
+            width: auto;
+        }
+
+        .domain-limit-row input[type="number"] {
+            width: 60px;
+            flex: 0;
+        }
+
+        .domain-limit-row button {
+            margin-top: 0;
+            padding: 5px 10px;
+            cursor: pointer;
+        }
+
+        .remove-btn {
+            background-color: #ff4444;
+            color: white;
+            border: none;
+            border-radius: 3px;
+        }
+
+        .add-btn {
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 3px;
+            padding: 8px 16px;
+        }
+
+        #domainLimitsList {
+            margin-top: 10px;
+        }
+
+        .hint {
+            font-size: 12px;
+            color: #666;
+            margin-top: 5px;
+        }
     </style>
 </head>
 
 <body>
     <h1>Tab Limiter Options</h1>
-    <div>
-        <label for="maxTabs">Maximum number of tabs:</label>
-        <input type="number" id="maxTabs" min="1" value="10">
+
+    <div class="section">
+        <label for="maxTabs">Global maximum number of tabs:</label>
+        <input type="number" id="maxTabs" min="1" value="40">
+        <p class="hint">Maximum total tabs allowed across all domains.</p>
     </div>
-    <div>
+
+    <div class="section">
+        <label>Per-Domain Tab Limits:</label>
+        <p class="hint">Set maximum tabs for specific domains (e.g., x.com, twitter.com). Domains are matched without "www." prefix.</p>
+        <div id="domainLimitsList"></div>
+        <div class="domain-limit-row">
+            <input type="text" id="newDomain" placeholder="e.g., x.com">
+            <input type="number" id="newLimit" min="1" value="3" placeholder="Max">
+            <button type="button" class="add-btn" id="addDomainBtn">Add</button>
+        </div>
+    </div>
+
+    <div class="section">
         <label for="excludedUrls">Excluded Domains or URLs (one per line):</label>
         <textarea id="excludedUrls" placeholder="e.g.\nexample.com\nhttps://www.google.com/"></textarea>
+        <p class="hint">Tabs matching these patterns will never be auto-closed.</p>
     </div>
-    <button id="saveButton">Save</button>
+
+    <button id="saveButton">Save All Settings</button>
     <p id="status"></p>
     <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -3,22 +3,113 @@ document.addEventListener('DOMContentLoaded', function () {
     let excludedUrlsTextarea = document.getElementById('excludedUrls');
     let saveButton = document.getElementById('saveButton');
     let status = document.getElementById('status');
+    let domainLimitsList = document.getElementById('domainLimitsList');
+    let newDomainInput = document.getElementById('newDomain');
+    let newLimitInput = document.getElementById('newLimit');
+    let addDomainBtn = document.getElementById('addDomainBtn');
+
+    // Current domain limits (loaded from storage)
+    let domainLimits = {};
 
     // Load existing values from storage
-    chrome.storage.local.get(['maxTabs', 'excludedUrls'], function (result) {
+    chrome.storage.local.get(['maxTabs', 'excludedUrls', 'domainLimits'], function (result) {
+        if (chrome.runtime.lastError) {
+            console.error('Error loading settings:', chrome.runtime.lastError);
+            return;
+        }
         if (result.maxTabs) {
             maxTabsInput.value = result.maxTabs;
         }
         if (result.excludedUrls) {
             excludedUrlsTextarea.value = result.excludedUrls.join('\n');
         }
+        if (result.domainLimits) {
+            domainLimits = result.domainLimits;
+            renderDomainLimits();
+        }
+    });
+
+    // Render the domain limits list
+    function renderDomainLimits() {
+        domainLimitsList.innerHTML = '';
+        for (const [domain, limit] of Object.entries(domainLimits)) {
+            const row = document.createElement('div');
+            row.className = 'domain-limit-row';
+            row.innerHTML = `
+                <input type="text" value="${domain}" readonly>
+                <input type="number" value="${limit}" min="1" data-domain="${domain}">
+                <button type="button" class="remove-btn" data-domain="${domain}">Remove</button>
+            `;
+            domainLimitsList.appendChild(row);
+        }
+
+        // Add event listeners for limit changes
+        domainLimitsList.querySelectorAll('input[type="number"]').forEach(input => {
+            input.addEventListener('change', function () {
+                const domain = this.dataset.domain;
+                const newLimit = parseInt(this.value);
+                if (!isNaN(newLimit) && newLimit >= 1) {
+                    domainLimits[domain] = newLimit;
+                }
+            });
+        });
+
+        // Add event listeners for remove buttons
+        domainLimitsList.querySelectorAll('.remove-btn').forEach(btn => {
+            btn.addEventListener('click', function () {
+                const domain = this.dataset.domain;
+                delete domainLimits[domain];
+                renderDomainLimits();
+            });
+        });
+    }
+
+    // Add new domain limit
+    addDomainBtn.addEventListener('click', function () {
+        let domain = newDomainInput.value.trim().toLowerCase();
+        const limit = parseInt(newLimitInput.value);
+
+        if (!domain) {
+            status.textContent = 'Please enter a domain name.';
+            status.style.color = 'red';
+            return;
+        }
+
+        if (isNaN(limit) || limit < 1) {
+            status.textContent = 'Please enter a valid limit (1 or more).';
+            status.style.color = 'red';
+            return;
+        }
+
+        // Remove www. prefix if present
+        domain = domain.replace(/^www\./, '');
+
+        // Remove protocol if present
+        domain = domain.replace(/^https?:\/\//, '');
+
+        // Remove path if present
+        domain = domain.split('/')[0];
+
+        if (domainLimits[domain]) {
+            status.textContent = `Domain "${domain}" already exists. Update its limit directly.`;
+            status.style.color = 'orange';
+            return;
+        }
+
+        domainLimits[domain] = limit;
+        renderDomainLimits();
+        newDomainInput.value = '';
+        newLimitInput.value = '3';
+        status.textContent = `Added limit for ${domain}.`;
+        status.style.color = 'green';
     });
 
     // Save new values to storage
     saveButton.addEventListener('click', function () {
         let maxTabs = parseInt(maxTabsInput.value);
         if (isNaN(maxTabs) || maxTabs < 1) {
-            status.textContent = 'Please enter a valid number greater than zero.';
+            status.textContent = 'Please enter a valid number greater than zero for global max tabs.';
+            status.style.color = 'red';
             return;
         }
         let excludedUrls = excludedUrlsTextarea.value
@@ -26,10 +117,25 @@ document.addEventListener('DOMContentLoaded', function () {
             .map(line => line.trim())
             .filter(line => line.length > 0);
 
-        chrome.storage.local.set({ 'maxTabs': maxTabs, 'excludedUrls': excludedUrls }, function () {
+        chrome.storage.local.set({
+            'maxTabs': maxTabs,
+            'excludedUrls': excludedUrls,
+            'domainLimits': domainLimits
+        }, function () {
+            if (chrome.runtime.lastError) {
+                console.error('Error saving settings:', chrome.runtime.lastError);
+                status.textContent = 'Error saving options.';
+                status.style.color = 'red';
+                return;
+            }
             status.textContent = 'Options saved.';
+            status.style.color = 'green';
             // Trigger a tab count check after saving
-            chrome.runtime.sendMessage({ action: 'checkTabCount' });
+            chrome.runtime.sendMessage({ action: 'checkTabCount' }, function () {
+                if (chrome.runtime.lastError) {
+                    console.error('Error triggering tab check:', chrome.runtime.lastError);
+                }
+            });
         });
     });
 });

--- a/popup.html
+++ b/popup.html
@@ -7,7 +7,7 @@
         body {
             font-family: Arial, sans-serif;
             margin: 10px;
-            width: 300px;
+            width: 320px;
         }
 
         label,
@@ -34,6 +34,37 @@
         button {
             margin-top: 10px;
         }
+
+        #domainLimitsInfo {
+            margin-top: 15px;
+            padding-top: 10px;
+            border-top: 1px solid #ddd;
+            font-size: 13px;
+        }
+
+        #domainLimitsInfo h3 {
+            margin: 0 0 8px 0;
+            font-size: 14px;
+        }
+
+        .domain-item {
+            display: flex;
+            justify-content: space-between;
+            padding: 3px 0;
+        }
+
+        .domain-name {
+            color: #333;
+        }
+
+        .domain-count {
+            color: #666;
+        }
+
+        .no-limits {
+            color: #999;
+            font-style: italic;
+        }
     </style>
 </head>
 
@@ -41,9 +72,13 @@
     <h1>Tab Limiter</h1>
     <div id="tabCount">Loading tab count...</div>
     <div>
-        <label for="maxTabs">Maximum tabs:</label>
-        <input type="number" id="maxTabs" min="1" value="10">
+        <label for="maxTabs">Global max tabs:</label>
+        <input type="number" id="maxTabs" min="1" value="40">
         <button id="saveButton">Save</button>
+    </div>
+    <div id="domainLimitsInfo">
+        <h3>Per-Domain Limits:</h3>
+        <div id="domainLimitsList"></div>
     </div>
     <button id="optionsButton">More Options</button>
     <p id="status"></p>

--- a/popup.js
+++ b/popup.js
@@ -3,17 +3,48 @@ document.addEventListener('DOMContentLoaded', function () {
     let saveButton = document.getElementById('saveButton');
     let optionsButton = document.getElementById('optionsButton');
     let tabCountDiv = document.getElementById('tabCount');
+    let domainLimitsList = document.getElementById('domainLimitsList');
     let status = document.getElementById('status');
 
-    // Load existing maxTabs value from storage
-    chrome.storage.local.get(['maxTabs'], function (result) {
+    // Load existing maxTabs value and domain limits from storage
+    chrome.storage.local.get(['maxTabs', 'domainLimits'], function (result) {
+        if (chrome.runtime.lastError) {
+            console.error('Error loading settings:', chrome.runtime.lastError);
+            return;
+        }
         if (result.maxTabs) {
             maxTabsInput.value = result.maxTabs;
         }
+        renderDomainLimits(result.domainLimits || {});
     });
+
+    // Render domain limits in the popup
+    function renderDomainLimits(domainLimits) {
+        const entries = Object.entries(domainLimits);
+        if (entries.length === 0) {
+            domainLimitsList.innerHTML = '<div class="no-limits">No domain limits set</div>';
+            return;
+        }
+
+        domainLimitsList.innerHTML = '';
+        for (const [domain, limit] of entries) {
+            const item = document.createElement('div');
+            item.className = 'domain-item';
+            item.innerHTML = `
+                <span class="domain-name">${domain}</span>
+                <span class="domain-count">max ${limit} tab${limit !== 1 ? 's' : ''}</span>
+            `;
+            domainLimitsList.appendChild(item);
+        }
+    }
 
     // Get current tab count
     chrome.runtime.sendMessage({ action: 'getTabStats' }, function (response) {
+        if (chrome.runtime.lastError) {
+            console.error('Error getting tab stats:', chrome.runtime.lastError);
+            tabCountDiv.textContent = 'Unable to get tab count.';
+            return;
+        }
         if (response && response.tabCount !== undefined) {
             tabCountDiv.textContent = `Total open tabs: ${response.tabCount}`;
         } else {
@@ -29,9 +60,18 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
         chrome.storage.local.set({ 'maxTabs': maxTabs }, function () {
+            if (chrome.runtime.lastError) {
+                console.error('Error saving settings:', chrome.runtime.lastError);
+                status.textContent = 'Error saving settings.';
+                return;
+            }
             status.textContent = 'Settings saved.';
             // Trigger a tab count check after saving
-            chrome.runtime.sendMessage({ action: 'checkTabCount' });
+            chrome.runtime.sendMessage({ action: 'checkTabCount' }, function () {
+                if (chrome.runtime.lastError) {
+                    console.error('Error triggering tab check:', chrome.runtime.lastError);
+                }
+            });
         });
     });
 


### PR DESCRIPTION
- Add domainLimits setting to limit tabs per domain (e.g., max 3 tabs for x.com)
- Update options page with UI to add/edit/remove domain limits
- Update popup to display configured domain limits
- Fix race condition in initialization (use async/await consistently)
- Fix service worker state loss by persisting tabTimestamps to storage
- Add proper error handling for chrome.runtime.lastError
- Sync default maxTabs value (40) across all files
- Bump version to 1.2